### PR TITLE
Remote debugging features

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -132,6 +132,7 @@ class ChromeTab {
 
     let promise = new Promise(res => this.resolveWork = res)
     this.test = opts
+
     if (this.state == 'idle') this.run()
     else if (this.state == 'running') this.reload()
     else if (this.state == 'badCode')
@@ -215,6 +216,7 @@ class ChromeTab {
 
   onMessageAdded({message}) {
     console.log(`[${this.id}]`, message.text)
+
     if (message.text == 'Zen.idle' && this.state == 'loading') {
       this.becomeIdle()
     }
@@ -231,13 +233,21 @@ class ChromeTab {
   }
 
   failTest(error, stack) {
-    this.finishTest({error, stack, fullName: this.test.testName})
+    const result = { error, stack, fullName: this.test.testName }
+
+    this.finishTest(result)
   }
 
   finishTest(msg) {
     msg.time = new Date() - this.startAt
-    if (this.resolveWork)
+
+    if (!this.test.logs || !this.test.logs.console) {
+      delete msg.log
+    }
+
+    if (this.resolveWork) {
       this.resolveWork(msg)
+    }
     this.resolveWork = null
     this.test = null
   }

--- a/lib/head.js
+++ b/lib/head.js
@@ -229,7 +229,7 @@ function openCloudWatch() {
   let focusedResult = store.get().results.find(r => r.fullName === focusedName)
   let aws = Zen.config.aws
   if (focusedResult) {
-    window.open(`https://${aws.region}.console.aws.amazon.com/cloudwatch/home?region=${aws.region}#logEventViewer:group=/aws/lambda/serverless-zen-dev-workTests;stream=${focusedResult.logStream}`)
+    window.open(`https://${aws.region}.console.aws.amazon.com/cloudwatch/home?region=${aws.region}#logEventViewer:group=/aws/lambda/zen-workTests;stream=${focusedResult.logStream}`)
   }
 }
 

--- a/lib/head.js
+++ b/lib/head.js
@@ -30,6 +30,13 @@ function serverMessage(msg) {
   let data = JSON.parse(msg.data)
 
   if (data.results && !data.runId) { // incremental update of results
+    data.results.forEach(result => {
+      if (!result.log) return
+
+      console.log("REMOTE LOGS:")
+      result.log.split('\n').forEach(s => console.log(s))
+    })
+    
     store.set({results: store.get().results.concat(data.results)})
   } else {
     // update our state from the server. If our code is out of date, update and re-run the focused test
@@ -74,7 +81,7 @@ function focusTest(name) {
 function runSingleTestOnRemote (name = store.get().focus) {
   const test = Latte.flatten().find(t => t.fullName === name)
   updateUrlForTest(name)
-  socket.send(JSON.stringify({type: 'filterTests', testNames: [test.fullName], run: true}))
+  socket.send(JSON.stringify({type: 'filterTests', testNames: [test.fullName], run: true, logs: { console: true }}))
 }
 
 function filterTests(opts={}) {

--- a/lib/latte.js
+++ b/lib/latte.js
@@ -242,7 +242,7 @@
     let hasFinished = false
     let timeoutPromise
     let setTimeoutPromise = ms => {
-      new RealPromise((res, rej) => {
+      timeoutPromise = new RealPromise((res, rej) => {
         currentTimeout = realSetTimeout(() => {
           if (hasFinished) return
           console.error('Timeout', cbOrTest.stack)

--- a/lib/latte.js
+++ b/lib/latte.js
@@ -240,16 +240,24 @@
   // Run user code with a timeout
   async function runWithTimeout(cbOrTest, context) {
     let hasFinished = false
-    let ms = 10000
-    let timeoutPromise = new RealPromise((res, rej) => {
-      currentTimeout = realSetTimeout(() => {
-        if (hasFinished) return
-        console.error('Timeout', cbOrTest.stack)
-        if (mode == 'headless') {
-          rej(`Timeout, the test took more than ${ms/1000}s on remote: ${cbOrTest.stack}`)
-        }
-      }, 10000)
-    })
+    let timeoutPromise
+    let setTimeoutPromise = ms => {
+      new RealPromise((res, rej) => {
+        currentTimeout = realSetTimeout(() => {
+          if (hasFinished) return
+          console.error('Timeout', cbOrTest.stack)
+          if (mode == 'headless') {
+            rej(`Timeout, the test took more than ${ms/1000}s on remote: ${cbOrTest.stack}`)
+          }
+        }, ms)
+      })
+    }
+    setTimeoutPromise(10000)
+    
+    context.extendRemoteTimeout = ms => {
+      clearTimeout(currentTimeout)
+      setTimeoutPromise(ms)
+    }
 
     let runPromise = null
     if (cbOrTest.fn.length > 0) {
@@ -270,9 +278,11 @@
     let suites = lineage(context._suite)
     if (topDown) suites = suites.reverse()
 
-    for (suite of suites)
-      for (cb of suite[type])
+    for (suite of suites) {
+      for (cb of suite[type]) {
         await runWithTimeout(cb, context)
+      }
+    }
   }
 
   // Get all the suites between the current one and the root.

--- a/lib/latte.js
+++ b/lib/latte.js
@@ -127,50 +127,61 @@
   Latte.run = async function latteRun(tests) {
     abort = false
 
-    for (test of tests) {
-      if (!test.fn) continue
-      console.log(`${test.fullName}`)
-      Latte.currentTest = test
-      whenCurrentTestFinished = new RealPromise(res => currentTestResolve = res)
+    let log = []
+    const originalConsoleLog = console.log
+    console.log = (...args) => {
+      log.push(args.join(' '))
+      originalConsoleLog.apply(console, args)
+    }
+    try {
+      for (test of tests) {
+        if (!test.fn) continue
+        console.log(`${test.fullName}`)
+        Latte.currentTest = test
+        whenCurrentTestFinished = new RealPromise(res => currentTestResolve = res)
 
-      // apply afterEach from the inside out
-      if (currentContext && mode == 'debug')
-        await applyCallbacks('afterEach', currentContext)
-
-      // each test gets a context that inherits from the suite-level context.
-      // This isolates each test but lets us do some setup at the suite-level for speed.
-      previousSuiteContext = currentContext && Object.getPrototypeOf(currentContext)
-      var suiteContext = await changeSuite(previousSuiteContext, test.suite)
-
-      currentContext = Object.create(suiteContext)
-      currentContext.currentTest = test
-      Latte.currentContext = currentContext
-
-      if (mode == 'headless') {
-        let error
-        try {
-          await applyCallbacks('beforeEach', currentContext, {topDown: true})
-          await runWithTimeout(test, currentContext)
-        } catch (e) {
-          realClearTimeout(currentTimeout)
-          error = e || 'undefined error'
+        // apply afterEach from the inside out
+        if (currentContext && mode == 'debug') {
+          await applyCallbacks('afterEach', currentContext)
         }
 
-        // AfterEach generally does cleanup. If it fails, it's unsafe to run more tests.
-        // By not catching exceptions here, we abort running and allow our chrome wrapper to reload.
-        await applyCallbacks('afterEach', currentContext)
-        Latte.onTest(test, error)
-      }
+        // each test gets a context that inherits from the suite-level context.
+        // This isolates each test but lets us do some setup at the suite-level for speed.
+        previousSuiteContext = currentContext && Object.getPrototypeOf(currentContext)
+        var suiteContext = await changeSuite(previousSuiteContext, test.suite)
 
-      if (mode == 'debug') {
-        await applyCallbacks('beforeEach', currentContext, {topDown: true})
-        await runWithTimeout(test, currentContext)
-        Latte.onTest(test)
-      }
+        currentContext = Object.create(suiteContext)
+        currentContext.currentTest = test
+        Latte.currentContext = currentContext
 
-      // signal that we've finished this test, in case we're aborting
-      currentTestResolve()
-      whenCurrentTestFinished = currentTestResolve = null
+        if (mode == 'headless') {
+          let error
+          try {
+            await applyCallbacks('beforeEach', currentContext, {topDown: true})
+            await runWithTimeout(test, currentContext)
+          } catch (e) {
+            realClearTimeout(currentTimeout)
+            error = e || 'undefined error'
+          }
+
+          // AfterEach generally does cleanup. If it fails, it's unsafe to run more tests.
+          // By not catching exceptions here, we abort running and allow our chrome wrapper to reload.
+          await applyCallbacks('afterEach', currentContext)
+          Latte.onTest(test, error, log)
+        }
+
+        if (mode == 'debug') {
+          await applyCallbacks('beforeEach', currentContext, {topDown: true})
+          await runWithTimeout(test, currentContext)
+          Latte.onTest(test, undefined, log)
+        }
+
+        // signal that we've finished this test, in case we're aborting
+        currentTestResolve()
+        whenCurrentTestFinished = currentTestResolve = null
+      }  
+    } finally {
+      console.log = originalConsoleLog
     }
   }
 
@@ -229,12 +240,13 @@
   // Run user code with a timeout
   async function runWithTimeout(cbOrTest, context) {
     let hasFinished = false
+    let ms = 10000
     let timeoutPromise = new RealPromise((res, rej) => {
       currentTimeout = realSetTimeout(() => {
         if (hasFinished) return
         console.error('Timeout', cbOrTest.stack)
         if (mode == 'headless') {
-          rej(`Timeout ${cbOrTest.stack}`)
+          rej(`Timeout, the test took more than ${ms/1000}s on remote: ${cbOrTest.stack}`)
         }
       }, 10000)
     })

--- a/lib/latte.js
+++ b/lib/latte.js
@@ -254,7 +254,8 @@
     }
     setTimeoutPromise(10000)
     
-    context.extendRemoteTimeout = ms => {
+    context.zen = {}
+    context.zen.extendRemoteTimeout = ms => {
       clearTimeout(currentTimeout)
       setTimeoutPromise(ms)
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -79,12 +79,12 @@ module.exports = class Server {
       }
 
       this.runId++
-      this.grep ? this.runLocally() : this.runOnLambda() // should this be if the tests will take less than x seconds?
+      this.grep ? this.runLocally() : this.runOnLambda(msg) // should this be if the tests will take less than x seconds?
       this.sendStatus()
     }
   }
 
-  async runOnLambda () {
+  async runOnLambda ({ logs }) {
     let startingRunId = this.runId
     console.log("RUN ON REMOTE", this.workingSet, Zen.config.lambdaConcurrency)
     let runGroups = Zen.journal.groupTests(this.workingSet, Zen.config.lambdaConcurrency)
@@ -97,7 +97,7 @@ module.exports = class Server {
 
     runGroups.forEach(async (group) => {
       try {
-        let response = await Util.invoke('zen-workTests', {testNames: group.tests, sessionId: Zen.config.sessionId})
+        let response = await Util.invoke('zen-workTests', {testNames: group.tests, sessionId: Zen.config.sessionId, logs })
         if (startingRunId !== this.runId) return
         this.onResults(response)
       } catch (e) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,7 +86,6 @@ module.exports = class Server {
 
   async runOnLambda ({ logs }) {
     let startingRunId = this.runId
-    console.log("RUN ON REMOTE", this.workingSet, Zen.config.lambdaConcurrency)
     let runGroups = Zen.journal.groupTests(this.workingSet, Zen.config.lambdaConcurrency)
     this.isLambda = true
     this.workerCount = runGroups.length

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -41,14 +41,14 @@
     await Latte.run(tests)
   }
 
-  Latte.onTest = function onTest(test, err) {
+  Latte.onTest = function onTest(test, err, log) {
     if (err && typeof(err) == 'string')
       err = new Error(err) // in case the user throws a string
 
     // errors aren't stringifyable, so just send the message and stack
     let error = err && err.message
     let stack = err && err.stack
-    console.info('Zen.results ' + JSON.stringify({fullName: test.fullName, error, stack, batchId, testNumber}))
+    console.info('Zen.results ' + JSON.stringify({fullName: test.fullName, error, stack, batchId, testNumber, log: log.join('\n') }))
     testNumber++
   }
 


### PR DESCRIPTION
2 logging related things
- Fixing the cloudwatch link so that it works to open remote logs
- Adding a way for when running a single test in remote we get back the console logs

2 things around remote timeouts were changed
- Timeout error is now a bit more obvious
- now a `extendRemoteTimeout` will be passed into tests to allow a way to change the timeout for tests that need it
