### PR TITLE
add logging for fn undefined

### DIFF
--- a/lib/latte.js
+++ b/lib/latte.js
@@ -306,6 +306,15 @@
       clearTimeout(currentTimeout)
       setTimeoutPromise(ms)
     }
+    
+    if (!cbOrTest.fn) {
+      currentStack = new Error().stack
+      throw new Error(`CbOrTest with undefined fn:
+        fn Stack: ${cbOrTest.stack}
+        current Stack: ${currentStack} 
+        cbOrTest: ${JSON.stringify(cbOrTest)}
+      `)
+    }
 
     let runPromise = null
     if (cbOrTest.fn.length > 0) {

--- a/lib/latte.js
+++ b/lib/latte.js
@@ -308,7 +308,7 @@
     }
     
     if (!cbOrTest.fn) {
-      currentStack = new Error().stack
+      const currentStack = new Error().stack
       throw new Error(`CbOrTest with undefined fn:
         fn Stack: ${cbOrTest.stack}
         current Stack: ${currentStack} 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -48,7 +48,19 @@
       return
     }
 
-    await Latte.run(tests)
+    try {
+      await Latte.run(tests)
+    } catch (err) {
+      if (err && typeof err == 'string') err = new Error(err) // in case the user throws a string
+      console.info(
+        'Zen.results ' + JSON.stringify({
+          runId,
+          fullName: opts.testName,
+          error: err.message,
+          stack: err.stack
+        })
+      )
+    }
   }
 
   Latte.onTest = function onTest(test, err, log) {


### PR DESCRIPTION
Adding more logging for `call of undefinded`. Also I added a bit better logging for when there is an error in zen, we should now see stack traces in the terminal output, which will help with debugging some of the zen internal bugs