### PR TITLE
Also set browser size via setDeviceMetricsOverride

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -136,6 +136,8 @@ module.exports = class ChromeWrapper {
 
     let tab = new ChromeTab(cdp, id, config, manifest)
     await cdp.Page.navigate({ url })
+    const { width = 800, height = 600 } = Zen.config.chrome || {}
+    await cdp.Emulation.setDeviceMetricsOverride({ width, height, fitWindow: true, deviceScaleFactor: 1, mobile: false });
     return tab
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
Prior change for browser dimensions wasn't working totally. 

With this change, browser resizing works both on local and remote when running an individual test, or a set of tests, **but still fails when running the entire suite. 😭** 

