### PR TITLE
Zen lambda code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,4 +3,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  rules: {
+    '@typescript-eslint/no-var-requires': 0
+  }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,6 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   rules: {
-    '@typescript-eslint/no-var-requires': 0
-  }
+    '@typescript-eslint/no-var-requires': 0,
+  },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 tmp
 serverless/.serverless
 build
+yarn-error.log

--- a/build.js
+++ b/build.js
@@ -25,6 +25,7 @@ esbuild
     platform: 'node',
     plugins: [nodeExternalsPlugin()],
     watch,
+    external: ['chrome-aws-lambda', 'puppeteer-core']
   })
   .catch(() => process.exit(1))
 
@@ -36,6 +37,7 @@ function buildSimpleFile(file, outfile, platform = 'browser') {
       platform,
       bundle: true,
       plugins: [nodeExternalsPlugin()],
+      external: ['chrome-aws-lambda', 'puppeteer-core'],
       watch,
     })
     .catch(() => process.exit(1))

--- a/build.js
+++ b/build.js
@@ -25,7 +25,7 @@ esbuild
     platform: 'node',
     plugins: [nodeExternalsPlugin()],
     watch,
-    external: ['chrome-aws-lambda', 'puppeteer-core']
+    external: ['chrome-aws-lambda', 'puppeteer-core'],
   })
   .catch(() => process.exit(1))
 

--- a/lib/aws.template
+++ b/lib/aws.template
@@ -197,12 +197,12 @@ Resources:
     Type: AWS::ApiGateway::Method
     DependsOn: RouteRequest
     Properties:
-      HttpMethod: ANY
+      HttpMethod: GET
       AuthorizationType: None
       RestApiId: !Ref GatewayApi
       ResourceId: !Ref GatewayResource
       Integration:
-        IntegrationHttpMethod: POST
+        IntegrationHttpMethod: GET
         Type: AWS_PROXY
         Uri: !Sub
           - 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lArn}/invocations'

--- a/lib/aws.template
+++ b/lib/aws.template
@@ -114,10 +114,10 @@ Resources:
       Handler: lambda.workTests
       MemorySize: 1536
       Role: !GetAtt ['LambdaRole', 'Arn']
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:1
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:14
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -135,10 +135,10 @@ Resources:
       Handler: lambda.listTests
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:1
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:14
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -156,7 +156,7 @@ Resources:
       Handler: lambda.sync
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Timeout: 60
       Environment:
         Variables:
@@ -172,7 +172,7 @@ Resources:
       Handler: lambda.routeRequest
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Timeout: 60
       Environment:
         Variables:

--- a/lib/aws.template
+++ b/lib/aws.template
@@ -117,7 +117,7 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:14
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:15
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -138,7 +138,7 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:14
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:15
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -202,7 +202,7 @@ Resources:
       RestApiId: !Ref GatewayApi
       ResourceId: !Ref GatewayResource
       Integration:
-        IntegrationHttpMethod: GET
+        IntegrationHttpMethod: POST
         Type: AWS_PROXY
         Uri: !Sub
           - 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lArn}/invocations'

--- a/lib/aws.template
+++ b/lib/aws.template
@@ -114,10 +114,10 @@ Resources:
       Handler: lambda.workTests
       MemorySize: 1536
       Role: !GetAtt ['LambdaRole', 'Arn']
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:15
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -135,10 +135,10 @@ Resources:
       Handler: lambda.listTests
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:15
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -156,7 +156,7 @@ Resources:
       Handler: lambda.sync
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: 60
       Environment:
         Variables:
@@ -172,7 +172,7 @@ Resources:
       Handler: lambda.routeRequest
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs14.x
+      Runtime: nodejs12.x
       Timeout: 60
       Environment:
         Variables:
@@ -197,7 +197,7 @@ Resources:
     Type: AWS::ApiGateway::Method
     DependsOn: RouteRequest
     Properties:
-      HttpMethod: GET
+      HttpMethod: ANY
       AuthorizationType: None
       RestApiId: !Ref GatewayApi
       ResourceId: !Ref GatewayResource

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -101,13 +101,11 @@ module.exports = class ChromeWrapper {
       socket
     while (!connected) {
       await new Promise((r) => setTimeout(r, 200))
-      console.log("attempting to connect")
       connected = await new Promise((resolve) => {
         socket = net.createConnection(9222)
         socket.once('connect', () => resolve(true))
         socket.once('error', () => resolve(false))
       })
-      console.log("connection", connected)
       socket.destroy()
     }
     console.log("Connection completed", connected)

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -3,6 +3,7 @@ const path = require('path')
 const spawn = require('child_process').spawn
 const net = require('net')
 const fs = require('fs')
+const AWS = require('aws-sdk')
 import * as ChromeLauncher from 'chrome-launcher'
 import * as Util from './util'
 
@@ -110,6 +111,7 @@ module.exports = class ChromeWrapper {
     }
     console.log("Connection completed", connected)
 
+    this.s3 = new AWS.S3({ params: { Bucket: process.env.ASSET_BUCKET } })
     this.getBrowser = CDP({ host: 'localhost', port: 9222 })
   }
 
@@ -138,7 +140,7 @@ module.exports = class ChromeWrapper {
     })
     console.log(`Opening ${url} in ${ua.value}`) // Useful when debugging different versions
 
-    let tab = new ChromeTab(cdp, id, config, manifest)
+    let tab = new ChromeTab(cdp, id, config, manifest, this.s3)
     await cdp.Page.navigate({ url })
     return tab
   }
@@ -151,12 +153,13 @@ module.exports = class ChromeWrapper {
 // hotReload: trying to update without a full page load
 // running: a test is in progress
 class ChromeTab {
-  constructor(cdp, id, config, manifest) {
+  constructor(cdp, id, config, manifest, s3) {
     this.id = id || 'Dev'
     this.config = config
     this.cdp = cdp
     this.state = 'loading'
     this.manifest = manifest
+    this.s3 = s3
     this.codeHash = null // the version we'd like to be running
     this.test = null // the test we're supposed to run
     this.resolveWork = null // function to call when we have test results
@@ -392,7 +395,19 @@ class ChromeTab {
     if (key) {
       let url = `${this.manifest.assetUrl}/${key}`
       console.log(`${path} redirected to ${url}`)
-      this.cdp.Fetch.continueRequest({ requestId, url })
+      if (!this.s3) throw new Error("s3 not defined")
+
+      const response = await this.s3.getObject({
+        Bucket: process.env.ASSET_BUCKET,
+        Key: key
+      }).promise()
+      const responseHeaders = [{ name: 'Content-Type', value: response.ContentType }]
+      this.cdp.Fetch.fulfillRequest({
+        requestId,
+        responseCode: 200,
+        body: response.Body.toString('base64'),
+        responseHeaders
+      })
     } else {
       console.log(`${path} missing from manifest`)
       let responseHeaders = [{ name: 'Content-Type', value: 'text/plain' }]

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -80,7 +80,7 @@ module.exports = class ChromeWrapper {
       '--enable-logging',
       '--log-level=0',
       '--v=1',
-      '--disable-web-security' // TODO figure out why S3 fetch requests are blocked, then remove this
+      '--disable-web-security', // TODO figure out why S3 fetch requests are blocked, then remove this
       // The default referrer policy was changed in chrome 85, this reverts
       // it to the way it worked before https://www.chromestatus.com/feature/6251880185331712
       '--force-legacy-default-referrer-policy'

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -82,7 +82,7 @@ module.exports = class ChromeWrapper {
       '--disable-web-security' // TODO figure out why S3 fetch requests are blocked, then remove this
     ]
 
-    this.process = spawn('/opt/layer-chrome/chromium', flags, {
+    this.process = spawn('/opt/chromium', flags, {
       detached: true,
       env: { TZ: 'America/New_York' },
       stdio: [
@@ -98,13 +98,16 @@ module.exports = class ChromeWrapper {
       socket
     while (!connected) {
       await new Promise((r) => setTimeout(r, 200))
+      console.log("attempting to connect")
       connected = await new Promise((resolve) => {
         socket = net.createConnection(9222)
         socket.once('connect', () => resolve(true))
         socket.once('error', () => resolve(false))
       })
+      console.log("connection", connected)
       socket.destroy()
     }
+    console.log("Connection completed", connected)
 
     this.getBrowser = CDP({ host: 'localhost', port: 9222 })
   }

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -80,11 +80,14 @@ module.exports = class ChromeWrapper {
       '--log-level=0',
       '--v=1',
       '--disable-web-security' // TODO figure out why S3 fetch requests are blocked, then remove this
+      // The default referrer policy was changed in chrome 85, this reverts
+      // it to the way it worked before https://www.chromestatus.com/feature/6251880185331712
+      '--force-legacy-default-referrer-policy'
     ]
 
-    this.process = spawn('/opt/chromium', flags, {
+    this.process = spawn(await require("chrome-aws-lambda").executablePath, flags, {
       detached: true,
-      env: { TZ: 'America/New_York' },
+      env: process.env,
       stdio: [
         'ignore',
         fs.openSync('/tmp/chrome-out.log', 'a'),

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -86,15 +86,19 @@ module.exports = class ChromeWrapper {
       '--force-legacy-default-referrer-policy'
     ]
 
-    this.process = spawn(await require("chrome-aws-lambda").executablePath, flags, {
-      detached: true,
-      env: process.env,
-      stdio: [
-        'ignore',
-        fs.openSync('/tmp/chrome-out.log', 'a'),
-        fs.openSync('/tmp/chrome-err.log', 'a'),
-      ],
-    })
+    this.process = spawn(
+      await require('chrome-aws-lambda').executablePath,
+      flags,
+      {
+        detached: true,
+        env: process.env,
+        stdio: [
+          'ignore',
+          fs.openSync('/tmp/chrome-out.log', 'a'),
+          fs.openSync('/tmp/chrome-err.log', 'a'),
+        ],
+      }
+    )
     console.log('Chrome spawned')
 
     // Repeatedly try and open a socket to the devtools port
@@ -109,7 +113,7 @@ module.exports = class ChromeWrapper {
       })
       socket.destroy()
     }
-    console.log("Connection completed", connected)
+    console.log('Connection completed', connected)
 
     this.s3 = new AWS.S3({ params: { Bucket: process.env.ASSET_BUCKET } })
     this.getBrowser = CDP({ host: 'localhost', port: 9222 })
@@ -395,18 +399,22 @@ class ChromeTab {
     if (key) {
       let url = `${this.manifest.assetUrl}/${key}`
       console.log(`${path} redirected to ${url}`)
-      if (!this.s3) throw new Error("s3 not defined")
+      if (!this.s3) throw new Error('s3 not defined')
 
-      const response = await this.s3.getObject({
-        Bucket: process.env.ASSET_BUCKET,
-        Key: key
-      }).promise()
-      const responseHeaders = [{ name: 'Content-Type', value: response.ContentType }]
+      const response = await this.s3
+        .getObject({
+          Bucket: process.env.ASSET_BUCKET,
+          Key: key,
+        })
+        .promise()
+      const responseHeaders = [
+        { name: 'Content-Type', value: response.ContentType },
+      ]
       this.cdp.Fetch.fulfillRequest({
         requestId,
         responseCode: 200,
         body: response.Body.toString('base64'),
-        responseHeaders
+        responseHeaders,
       })
     } else {
       console.log(`${path} missing from manifest`)

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -91,7 +91,7 @@ module.exports = class ChromeWrapper {
       flags,
       {
         detached: true,
-        env: process.env,
+        env: { ...process.env, TZ: 'America/New_York' },
         stdio: [
           'ignore',
           fs.openSync('/tmp/chrome-out.log', 'a'),
@@ -397,25 +397,33 @@ class ChromeTab {
 
     let key = this.manifest.fileMap[path]
     if (key) {
-      let url = `${this.manifest.assetUrl}/${key}`
-      console.log(`${path} redirected to ${url}`)
-      if (!this.s3) throw new Error('s3 not defined')
+      try {
+        let url = `${this.manifest.assetUrl}/${key}`
+        console.log(`${path} redirected to ${url}`)
+        if (!this.s3) throw new Error('s3 not defined')
 
-      const response = await this.s3
-        .getObject({
-          Bucket: process.env.ASSET_BUCKET,
-          Key: key,
+        const response = await this.s3
+          .getObject({
+            Bucket: process.env.ASSET_BUCKET,
+            Key: key,
+          })
+          .promise()
+        const responseHeaders = [
+          { name: 'Content-Type', value: response.ContentType },
+        ]
+        const body = response.Body.toString('base64')
+
+        await this.cdp.Fetch.fulfillRequest({
+          requestId,
+          responseCode: 200,
+          body,
+          responseHeaders,
         })
-        .promise()
-      const responseHeaders = [
-        { name: 'Content-Type', value: response.ContentType },
-      ]
-      this.cdp.Fetch.fulfillRequest({
-        requestId,
-        responseCode: 200,
-        body: response.Body.toString('base64'),
-        responseHeaders,
-      })
+      } catch (e) {
+        // There is a chance for a redirect or new tab while this s3 request is going through
+        // if we try to fulfill a request that has been canceled chrome gets really angry
+        console.error(e)
+      }
     } else {
       console.log(`${path} missing from manifest`)
       let responseHeaders = [{ name: 'Content-Type', value: 'text/plain' }]

--- a/lib/s3-sync.js
+++ b/lib/s3-sync.js
@@ -106,7 +106,7 @@ module.exports = class S3Sync extends EventEmitter {
         mime.contentType(path.basename(f.path)) ||
         'application/octet-stream'
 
-      let result = await this.s3.upload({ ACL: 'public-read', Key, Body, ContentType }).promise()
+      let result = await this.s3.upload({ Key, Body, ContentType }).promise()
       // TODO handle an individual upload failure
       this.announce({ uploaded: this.status.uploaded + 1 })
       this.announce(`Uploading ${++uploaded}/${needed.length}`)

--- a/lib/s3-sync.js
+++ b/lib/s3-sync.js
@@ -106,7 +106,7 @@ module.exports = class S3Sync extends EventEmitter {
         mime.contentType(path.basename(f.path)) ||
         'application/octet-stream'
 
-      let result = await this.s3.upload({ Key, Body, ContentType }).promise()
+      let result = await this.s3.upload({ ACL: 'public-read', Key, Body, ContentType }).promise()
       // TODO handle an individual upload failure
       this.announce({ uploaded: this.status.uploaded + 1 })
       this.announce(`Uploading ${++uploaded}/${needed.length}`)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "aws-sdk": "^2.238.1",
     "btoa": "^1.2.1",
     "chrome-launcher": "^0.10.2",
-    "chrome-remote-interface": "^0.27.1",
+    "chrome-remote-interface": "^0.28.1",
     "connect": "^3.6.1",
     "fuzzysort": "^1.1.4",
     "klaw": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "node ./build.js",
     "start": "node ./build.js -w",
     "prepare": "npm run build",
-    "upload-lambda-code": "ts-node ./tools/upload_lambda.ts"
+    "tools:upload-lambda": "ts-node ./tools/upload_lambda.ts"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write --ignore-unknown .",
     "build": "node ./build.js",
     "start": "node ./build.js -w",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "upload-lambda-code": "ts-node ./tools/upload_lambda.ts"
   },
   "repository": {
     "type": "git",
@@ -52,14 +53,18 @@
     "@types/webpack": "^4.41.31",
     "@types/webpack-dev-server": "^3",
     "@types/webpack-env": "^1.16.3",
+    "@types/adm-zip": "^0.4.34",
+    "@types/aws-sdk": "^2.7.0",
     "@types/yargs": "^17.0.2",
     "@typescript-eslint/eslint-plugin": "^4.31.2",
     "@typescript-eslint/parser": "^4.31.2",
+    "adm-zip": "^0.5.9",
     "chai": "^3.5.0",
     "esbuild": "^0.12.28",
     "esbuild-node-externals": "^1.3.0",
     "eslint": "^7.32.0",
     "prettier": "^2.4.1",
+    "ts-node": "^10.4.0",
     "typescript": "^4.4.3",
     "webpack": "4.46.0",
     "webpack-dev-server": "^3.4"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@typescript-eslint/parser": "^4.31.2",
     "adm-zip": "^0.5.9",
     "chai": "^3.5.0",
+    "chrome-aws-lambda": "2.1.1",
     "esbuild": "^0.12.28",
     "esbuild-node-externals": "^1.3.0",
     "eslint": "^7.32.0",

--- a/tools/build_layer.sh
+++ b/tools/build_layer.sh
@@ -1,0 +1,18 @@
+# Clean up the artifacts if they still exits
+rm -rf build/chrome-aws-lambda && rm -rf build/layer.zip
+
+# chrome-aws-lambda provides a layer with many of the dependencies
+# for chrome already setup
+git clone https://github.com/alixaxel/chrome-aws-lambda.git build/chrome-aws-lambda
+cd build/chrome-aws-lambda
+
+# version 2.1.1, chrome 80
+git checkout ba8cde3f992fc387ede9b047afee9a4f3eb5ca5c
+make ../layer.zip
+
+echo "
+DONE BUILDING :D
+
+Take build/layer.zip and create a new layer with it at
+https://us-west-1.console.aws.amazon.com/lambda/home?region=us-west-1#/layers
+"

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compileOptions": {
+    "target": "node",
+    "checkJs": true
+  }
+}

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -43,10 +43,6 @@ AWS.config.update({
   secretAccessKey,
   accessKeyId,
   region: 'us-west-1',
-  apigateway: {
-    endpoint: 'https://14lcmc9k91.execute-api.us-west-1.amazonaws.com/pub',
-  },
-  // s3CacheVersion: 1
 })
 const s3 = new AWS.S3({ params: { Bucket: assetBucket } })
 

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -56,8 +56,8 @@ const body = zip.toBuffer()
 const contentType = 'application/zip, application/octet-stream'
 s3.upload({ Key: key, Body: body, ContentType: contentType } as any)
   .promise()
-  .then((result: unknown) => {
-    console.log('Upload finished!', result)
+  .then(() => {
+    console.log('Upload finished!')
   })
   .catch((e: unknown) => {
     console.error(e)

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -15,7 +15,7 @@ files.forEach(file => {
     bundleConfig = {
       bundle: true,
       // These are in the lambda layer we use and do not need to be bundled
-      external: ['chrome-aws-lambda', 'puppeteer-core']
+      external: ['chrome-aws-lambda', 'puppeteer-core', 'aws-sdk']
     }
   }
   esbuild.buildSync({

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -25,14 +25,18 @@ const s3 = new AWS.S3({ params: { Bucket: assetBucket } })
 
 // Create a the zip file
 const zip = new AdmZip()
-esbuild.buildSync({
-  entryPoints: [path.join(__dirname, '../lib/lambda.js'), path.join(__dirname, '../lib/chrome.js')],
-  platform: 'node',
-  bundle: true,
-  outdir: path.join(__dirname, '../build/lambda_code')
+const files = ['lambda', 'chrome']
+files.forEach(file => {
+  esbuild.buildSync({
+    entryPoints: [path.join(__dirname, `../lib/${file}.js`)],
+    platform: 'node',
+    bundle: file !== 'lambda',
+    outfile: path.join(__dirname, '../build/lambda_code', file + '.js')
+  })
+  zip.addLocalFile(path.join(__dirname, `../build/lambda_code/${file}.js`))
 })
-zip.addLocalFile(path.join(__dirname, '../build/lambda_code/lambda.js'))
-zip.addLocalFile(path.join(__dirname, '../build/lambda_code/chrome.js'))
+
+zip.writeZip(path.join(__dirname, '../build/lambda_code/lambda-code.zip'))
 
 // Send the zip up to S3
 const key = 'lambda-code.zip'

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -1,0 +1,49 @@
+const AWS = require('aws-sdk')
+const AdmZip = require('adm-zip')
+const path = require('path')
+const esbuild = require('esbuild')
+
+const assetBucket = process.env.ASSET_BUCKET
+const secretAccessKey = process.env.SECRET_ACCESS_KEY
+const accessKeyId = process.env.ACCESS_KEY_ID
+if (!assetBucket || !secretAccessKey || !accessKeyId) {
+  console.log('You need to set AWS premissions to do the upload')
+  process.exit(1)
+}
+
+// Setup AWS
+AWS.config.update({
+  secretAccessKey,
+  accessKeyId,
+  region: 'us-west-1',
+  apigateway: {
+    endpoint: 'https://14lcmc9k91.execute-api.us-west-1.amazonaws.com/pub',
+  },
+  // s3CacheVersion: 1
+})
+const s3 = new AWS.S3({ params: { Bucket: assetBucket } })
+
+// Create a the zip file
+const zip = new AdmZip()
+esbuild.buildSync({
+  entryPoints: [path.join(__dirname, '../lib/lambda.js'), path.join(__dirname, '../lib/chrome.js')],
+  platform: 'node',
+  bundle: true,
+  outdir: path.join(__dirname, '../build/lambda_code')
+})
+zip.addLocalFile(path.join(__dirname, '../build/lambda_code/lambda.js'))
+zip.addLocalFile(path.join(__dirname, '../build/lambda_code/chrome.js'))
+
+// Send the zip up to S3
+const key = 'lambda-code.zip'
+const body = zip.toBuffer()
+const contentType = 'application/zip, application/octet-stream'
+s3.upload({ Key: key, Body: body, ContentType: contentType } as any)
+  .promise()
+  .then((result: unknown) => {
+    console.log('Upload finished!', result)
+  })
+  .catch((e: unknown) => {
+    console.error(e)
+    process.exit(1)
+  })

--- a/tools/upload_lambda.ts
+++ b/tools/upload_lambda.ts
@@ -6,29 +6,28 @@ const esbuild = require('esbuild')
 // Create a the zip file
 const zip = new AdmZip()
 const files = ['lambda', 'chrome']
-files.forEach(file => {
+files.forEach((file) => {
   // TODO make this use partial esbuild config
-  let bundleConfig : any = {
-    bundle: false
+  let bundleConfig: any = {
+    bundle: false,
   }
   if (file !== 'lambda') {
     bundleConfig = {
       bundle: true,
       // These are in the lambda layer we use and do not need to be bundled
-      external: ['chrome-aws-lambda', 'puppeteer-core', 'aws-sdk']
+      external: ['chrome-aws-lambda', 'puppeteer-core', 'aws-sdk'],
     }
   }
   esbuild.buildSync({
     entryPoints: [path.join(__dirname, `../lib/${file}.js`)],
     platform: 'node',
     outfile: path.join(__dirname, '../build/lambda_code', file + '.js'),
-    ...bundleConfig
+    ...bundleConfig,
   })
   zip.addLocalFile(path.join(__dirname, `../build/lambda_code/${file}.js`))
 })
 
 zip.writeZip(path.join(__dirname, '../build/lambda_code/lambda-code.zip'))
-
 
 const assetBucket = process.env.ASSET_BUCKET
 const secretAccessKey = process.env.SECRET_ACCESS_KEY

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,18 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -95,6 +107,40 @@
   integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
   dependencies:
     "@types/node" "*"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
+  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
+  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
+  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
+  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+
+"@types/adm-zip@^0.4.34":
+  version "0.4.34"
+  resolved "https://registry.yarnpkg.com/@types/adm-zip/-/adm-zip-0.4.34.tgz#62ac859eb2af6024362a1b3e43527ab79e0c624e"
+  integrity sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/aws-sdk@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@types/aws-sdk/-/aws-sdk-2.7.0.tgz#83588b3d14ebdca1d4ce5e023387577568ce82f3"
+  integrity sha1-g1iLPRTr3KHUzl4CM4dXdWjOgvM=
+  dependencies:
+    aws-sdk "*"
 
 "@types/core-js@^0.9.41":
   version "0.9.46"
@@ -503,6 +549,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -512,6 +563,16 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
+  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+
+adm-zip@^0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.9.tgz#b33691028333821c0cf95c31374c5462f2905a83"
+  integrity sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==
 
 ajv-errors@^1.0.0:
   version "1.0.0"
@@ -621,6 +682,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -709,6 +775,21 @@ async@^1.5.2:
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
+
+aws-sdk@*:
+  version "2.1014.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1014.0.tgz#b08bf963bee7256dd08a275f89fe5f1b67a735ba"
+  integrity sha512-QqxCSJ0egEUaI9gnYNybCdSCtP1HvgzInYo/MuOalXp+7cOuxG5OoN3KAjIEw6JmH2IiB9NGSKJZY6D0F4hJoQ==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
 
 aws-sdk@^2.238.1:
   version "2.238.1"
@@ -902,6 +983,15 @@ buffer-xor@^1.0.3:
 buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1282,6 +1372,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1447,6 +1542,11 @@ detect-libc@^1.0.2:
 detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -2351,6 +2451,11 @@ iconv-lite@^0.4.4:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
@@ -2800,6 +2905,11 @@ make-dir@^2.0.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 map-age-cleaner@^0.1.1:
   version "0.1.2"
@@ -4374,6 +4484,24 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
 
+ts-node@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.4.0.tgz#680f88945885f4e6cf450e7f0d6223dd404895f7"
+  integrity sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==
+  dependencies:
+    "@cspotcode/source-map-support" "0.7.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    yn "3.1.1"
+
 tslib@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
@@ -4534,13 +4662,13 @@ uuid@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
+uuid@3.3.2, uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 uuid@^3.0.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-uuid@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -4755,11 +4883,24 @@ xml2js@0.4.17:
     sax ">=0.6.0"
     xmlbuilder "^4.1.0"
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
   dependencies:
     lodash "^4.0.0"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
@@ -4824,6 +4965,11 @@ yargs@^17.1.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,12 +1181,13 @@ chrome-launcher@^0.10.2:
     mkdirp "0.5.1"
     rimraf "^2.6.1"
 
-chrome-remote-interface@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.27.1.tgz#d1f876b5433b87c00a6ce459b4c6ed60d8a36fb8"
+chrome-remote-interface@^0.28.1:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.28.2.tgz#6be3554d2c227ff07eb74baa7e5d4911da12a5a6"
+  integrity sha512-F7mjof7rWvRNsJqhVXuiFU/HWySCxTA9tzpLxUJxVfdLkljwFJ1aMp08AnwXRmmP7r12/doTDOMwaNhFCJsacw==
   dependencies:
     commander "2.11.x"
-    ws "^6.1.0"
+    ws "^7.2.0"
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -4963,11 +4964,10 @@ ws@^3.1.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-ws@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  dependencies:
-    async-limiter "~1.0.0"
+ws@^7.2.0:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
+  integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==
 
 xml2js@0.4.17:
   version "0.4.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,11 @@ base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -843,6 +848,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 bluebird@^3.5.5:
   version "3.7.2"
@@ -997,6 +1011,14 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -1138,6 +1160,13 @@ chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chrome-aws-lambda@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/chrome-aws-lambda/-/chrome-aws-lambda-2.1.1.tgz#2aeb0c97fb67e908d06dc8d92d92c7d4fb58467c"
+  integrity sha512-Wer2QuygxsCov5bM2+8CLa6qYpNsc5AxYTlgTne00aFoxFP491LGJRxOQtGnYtsJP6UG4pB0SfrwTyPnLys1Lw==
+  dependencies:
+    lambdafs "^1.3.0"
 
 chrome-launcher@^0.10.2:
   version "0.10.2"
@@ -1636,6 +1665,13 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+end-of-stream@^1.4.1:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
+
 enhanced-resolve@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz#2f3cfd84dbe3b487f18f2db2ef1e064a571ca5ec"
@@ -2130,6 +2166,11 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2460,6 +2501,11 @@ ieee754@1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ieee754@^1.1.4:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.11.tgz#c16384ffe00f5b7835824e67b6f2bd44a5229455"
@@ -2522,6 +2568,11 @@ inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, i
 inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@~1.3.0:
   version "1.3.5"
@@ -2808,6 +2859,13 @@ klaw@^2.1.1:
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.1.1.tgz#42b76894701169cc910fd0d19ce677b5fb378af1"
   dependencies:
     graceful-fs "^4.1.9"
+
+lambdafs@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/lambdafs/-/lambdafs-1.3.0.tgz#7e369cedc9a09623bb365fa99a1113c2ab2fc7ae"
+  integrity sha512-HqRPmEgtkTW4sCYDUjTEuTGkjCHuLvtZU8iM8GkhD7SpjW4AJJbBk86YU4K43sWGuW5Vmzp1lVCx4ab/kJsuBw==
+  dependencies:
+    tar-fs "^2.0.0"
 
 lcid@^2.0.0:
   version "2.0.0"
@@ -3105,6 +3163,11 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -3754,6 +3817,15 @@ readable-stream@^3.0.6:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readdirp@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -4388,6 +4460,27 @@ tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+
+tar-fs@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
+  integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^4:
   version "4.4.2"


### PR DESCRIPTION
The main parts of this change are in 
- aws.template -- the new node version allows lambda to update the code, this was not allowed on the deprecated node8 lambdas
- chrome.js -- Changes to lambdaLaunch to use config from the new lambda layer we are based off of
- s3-sync - Making the s3 sync explicitly public appears to currently be required to make zen work (I am working to remove that and add a some auth to the requests done in the lambda)

New tools folder. I created 2 tools to make this part of the development a bit easier
- upload_lambda will build, package and upload new lambda code (you still have to manually hit deploy)
- build_layer will create the layer we currently use from `chrome-aws-lambda`'s nice make file (you still have to do the full upload and update of ARN in aws.template)
