### PR TITLE
Kyle/desk 2923

### DIFF
--- a/lib/aws.template
+++ b/lib/aws.template
@@ -114,7 +114,7 @@ Resources:
       Handler: lambda.workTests
       MemorySize: 1536
       Role: !GetAtt ['LambdaRole', 'Arn']
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
         - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
@@ -135,7 +135,7 @@ Resources:
       Handler: lambda.listTests
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 60
       Layers:
         - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
@@ -156,7 +156,7 @@ Resources:
       Handler: lambda.sync
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 60
       Environment:
         Variables:
@@ -172,7 +172,7 @@ Resources:
       Handler: lambda.routeRequest
       MemorySize: 1536
       Role: !GetAtt [LambdaRole, Arn]
-      Runtime: nodejs12.x
+      Runtime: nodejs14.x
       Timeout: 60
       Environment:
         Variables:

--- a/lib/aws.template
+++ b/lib/aws.template
@@ -117,7 +117,7 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:19
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket
@@ -138,7 +138,7 @@ Resources:
       Runtime: nodejs14.x
       Timeout: 60
       Layers:
-        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:16
+        - arn:aws:lambda:us-west-1:977179729379:layer:chrome:19
       Environment:
         Variables:
           ASSET_BUCKET: !Ref AssetBucket

--- a/tools/build_layer.sh
+++ b/tools/build_layer.sh
@@ -6,8 +6,10 @@ rm -rf build/chrome-aws-lambda && rm -rf build/layer.zip
 git clone https://github.com/alixaxel/chrome-aws-lambda.git build/chrome-aws-lambda
 cd build/chrome-aws-lambda
 
-# version 2.1.1, chrome 80
-git checkout ba8cde3f992fc387ede9b047afee9a4f3eb5ca5c
+# version 8.2.0, chrome 90
+git checkout 5201d6bfe62e0606c5f24229a94f04a059ea7b30
+# Locks their typescript version, the build breaks with anything after this version
+npm install typescript@4.3.2
 make ../layer.zip
 
 echo "


### PR DESCRIPTION
Update the build to use chrome 90

We are blocked on chrome 91 and 92 build because they contain this issue https://www.notion.so/superhuman/ALTER-TABLE-Crash-Prevention-1b7f5b9cbb4441e288073ef96c208c08 and we added back and `ALTER TABLE` as part of the contact syncing work. 

