### PR TITLE
Remove runtime error and actually start tests for race

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -28,7 +28,6 @@ module.exports = class ChromeWrapper {
   // https://github.com/adieuadieu/serverless-chrome/tree/master/packages/lambda - the old launch I used to use
   // https://github.com/GoogleChrome/chrome-launcher/ - yet another launcher
   async launchLambda() {
-    const { width = 800, height = 600 } = Zen.config.chrome || {}
     let flags = [
       '--disable-background-timer-throttling',
       '--disable-breakpad',
@@ -75,7 +74,7 @@ module.exports = class ChromeWrapper {
       '--headless',
       '--single-process',
       '--remote-debugging-port=9222',
-      `--window-size=${width},${height}`,
+      `--window-size=800,600`,
       '--user-data-dir=/tmp/chromeUserData',
       '--enable-logging',
       '--log-level=0',

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -4,10 +4,10 @@ let wrapper // store chrome wrapper globally. In theory we could reuse this betw
 module.exports.workTests = async (opts, context) => {
   // TODO: the 1s buffer will help, most of the time but the extendRemoteTimeout may cause issues with this
   
-  // 10s is the default timeout for tests
-  // 1s to handle the surrounding zen code to run
+  // 5s to safely setup zen
   const maxRunTime = (opts.lambdaCutoff || 60) * 1000 - 5_000
-  const cutoff = Date.now() + maxRunTime
+  // 5s more off to have a safe 10s to run a final test
+  const cutoff = Date.now() + maxRunTime - 5_000
   const cutoffTimeout = new Promise(res => setTimeout(res, maxRunTime))
   let results = []
   const runTests = async () => {

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -6,16 +6,11 @@ module.exports.workTests = async (opts, context) => {
   
   // 10s is the default timeout for tests
   // 1s to handle the surrounding zen code to run
-  const maxRunTime = (opts.lambdaCutoff || 60) * 1000 - 10_000
+  const maxRunTime = (opts.lambdaCutoff || 60) * 1000 - 5_000
   const cutoff = Date.now() + maxRunTime
   const cutoffTimeout = new Promise(res => setTimeout(res, maxRunTime))
-
-  let tab = await prepareChrome(opts)
   let results = []
-  
-  // In case we get too close to the timeout, exit out and preserve the test results
-  // we have so far.
-  await Promise.race([cutoffTimeout, async () => {
+  const runTests = async () => {
     // Run all tests once, collecting results
     console.log('Starting tests')
     let remaining = opts.testNames.slice()
@@ -50,7 +45,10 @@ module.exports.workTests = async (opts, context) => {
         results.splice(results.indexOf(previousResult), 1, r) // replace previous result
       }
     }
-  }])
+  }
+
+  let tab = await prepareChrome(opts)
+  await Promise.race([cutoffTimeout, runTests()])
   
   // Track the logStreamName, so it's easy to open the logs of a failed test
   results.forEach((r) => (r.logStream = context.logStreamName))


### PR DESCRIPTION
This code is already deployed in lambda, because it was needed to fix zen. 