### PR TITLE
pass through the response from s3

### DIFF
--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -454,22 +454,6 @@ export default class ChromeWrapper {
     }
   }
 
-  async launchLambda(): Promise<Puppeteer.Browser | undefined> {
-    try {
-      this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET } })
-      const executablePath = await require('chrome-aws-lambda').executablePath
-      this.browser = Puppeteer.launch({
-        debuggingPort: 9222,
-        executablePath,
-        env: { ...process.env, TZ: 'America/New_York' },
-        args: lambdaChromeFlags,
-      })
-      return await this.browser
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
   async launchLambda() : Promise<Puppeteer.Browser | undefined> {
     try {
       this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET } })

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -445,6 +445,8 @@ export default class ChromeWrapper {
       // When running locally, just use puppeteer because it bundles chromium with it
       const Puppeteer = require('puppeteer')
       this.browser = Puppeteer.launch({
+        // TODO this should not use macos as the default, probably install for local build
+        executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
         debuggingPort: port,
         headless: true,
         args: [...localChromeFlags, `--window-size=${width},${height}`],
@@ -463,6 +465,22 @@ export default class ChromeWrapper {
         executablePath,
         env: { ...process.env, TZ: 'America/New_York' },
         args: lambdaChromeFlags,
+      })
+      return await this.browser
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async launchLambda() : Promise<Puppeteer.Browser | undefined> {
+    try {
+      this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET }})
+      const executablePath = await require('chrome-aws-lambda').executablePath
+      this.browser = Puppeteer.launch({
+        debuggingPort: 9222,
+        executablePath,
+        env: { ...process.env, TZ: 'America/New_York' },
+        args: lambdaChromeFlags
       })
       return await this.browser
     } catch (e) {

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -454,7 +454,7 @@ export default class ChromeWrapper {
     }
   }
 
-  async launchLambda() : Promise<Puppeteer.Browser | undefined> {
+  async launchLambda(): Promise<Puppeteer.Browser | undefined> {
     try {
       this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET } })
       const executablePath = await require('chrome-aws-lambda').executablePath

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -407,7 +407,7 @@ class ChromeTab {
             Key: key,
           })
           .promise()
-        const body = response.Body?.toString()
+        const body = response.Body as Buffer
 
         await request.respond({
           status: 200,

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -445,8 +445,6 @@ export default class ChromeWrapper {
       // When running locally, just use puppeteer because it bundles chromium with it
       const Puppeteer = require('puppeteer')
       this.browser = Puppeteer.launch({
-        // TODO this should not use macos as the default, probably install for local build
-        executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
         debuggingPort: port,
         headless: true,
         args: [...localChromeFlags, `--window-size=${width},${height}`],
@@ -474,13 +472,13 @@ export default class ChromeWrapper {
 
   async launchLambda() : Promise<Puppeteer.Browser | undefined> {
     try {
-      this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET }})
+      this.s3 = new S3({ params: { Bucket: process.env.ASSET_BUCKET } })
       const executablePath = await require('chrome-aws-lambda').executablePath
       this.browser = Puppeteer.launch({
         debuggingPort: 9222,
         executablePath,
         env: { ...process.env, TZ: 'America/New_York' },
-        args: lambdaChromeFlags
+        args: lambdaChromeFlags,
       })
       return await this.browser
     } catch (e) {


### PR DESCRIPTION
This fixes tests that used nontext fixtures like images. The toString call mangled the content and broke them :(