### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
This change should have gone with https://github.com/superhuman/zen/pull/42. 

Hopefully this allows us to update the [website](https://github.com/superhuman/website/blob/master/package.json#L12) with the updated dependency tree.