### PR TITLE
Remove the local chromium workers

### DIFF
--- a/lib/head.js
+++ b/lib/head.js
@@ -268,19 +268,13 @@ Zen.commands = [
   {
     type: 'command',
     title: 'Debug on S3',
-    action: () => runBatchForFocus({ s3: true }),
+    action: () => runBatchForFocus(),
     icon: Zen.icons.Bug,
   },
   {
     type: 'command',
     title: 'Show logs in Amazon CloudWatch',
     action: () => openCloudWatch(),
-    icon: Zen.icons.Bug,
-  },
-  {
-    type: 'command',
-    title: 'Dev: Reload headless chrome',
-    action: () => filterTests({ reload: true, force: true }),
     icon: Zen.icons.Bug,
   },
 ]
@@ -308,13 +302,10 @@ function batchForFocus(results, focus) {
     .sort((a, b) => parseInt(b.testNumber) - parseInt(a.testNumber))
 }
 
-function runBatchForFocus({ s3 } = {}) {
+function runBatchForFocus() {
   let batch = store.get().batchForFocus
   let jsonUrl = encodeURIComponent(JSON.stringify(batch.map((r) => r.fullName)))
-  let base = location.origin + '/worker?id=d&batch='
-  if (s3) {
-    base = Zen.config.proxyUrl + '/index.html?batch='
-  }
+  const base = Zen.config.proxyUrl + '/index.html?batch='
   window.open(base + jsonUrl, '_blank')
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -125,7 +125,8 @@ export default async function initZen(configFilePath: string): Promise<Zen> {
       window.Zen = {config: ${JSON.stringify(cfg)}}
     </script>`)
 
-      return zen.config.htmlTemplate.replace('ZEN_SCRIPTS', scripts.join('\n'))
+      const html = zen.config.htmlTemplate.replace('ZEN_SCRIPTS', scripts.join('\n'))
+      return html
     },
   })
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -125,7 +125,10 @@ export default async function initZen(configFilePath: string): Promise<Zen> {
       window.Zen = {config: ${JSON.stringify(cfg)}}
     </script>`)
 
-      const html = zen.config.htmlTemplate.replace('ZEN_SCRIPTS', scripts.join('\n'))
+      const html = zen.config.htmlTemplate.replace(
+        'ZEN_SCRIPTS',
+        scripts.join('\n')
+      )
       return html
     },
   })

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,7 +35,7 @@ module.exports = class Server {
     if (Zen.webpack) {
       Zen.webpack.startDevServer(app)
       Zen.webpack.on('status', () => {
-        this.sendStatus() 
+        this.sendStatus()
       })
     }
 
@@ -51,7 +51,7 @@ module.exports = class Server {
       resp.end(Zen.indexHtml(req.url.match(/^\/worker/) ? 'worker' : 'head'))
     })
   }
-  
+
   filterTests(msg) {
     // If nothing has changed and we're not running, leave the state unchanged.
     // When you refresh `head`, we don't want to run or clear out results unless the grep changed.

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,13 +9,11 @@ const {
   workTests,
   wsSend,
 } = require('./util')
-const ChromeWrapper = require('./chrome_wrapper').default
 
 module.exports = class Server {
   constructor() {
     this.runId = 1
     this.head = null
-    this.workers = Array.construct(8, (id) => ({ id: id + 1 }))
     this.isLambda = false
     this.workerCount = 0
     this.workingSet = []
@@ -36,54 +34,24 @@ module.exports = class Server {
 
     if (Zen.webpack) {
       Zen.webpack.startDevServer(app)
-      Zen.webpack.on('status', (stats) => {
-        if (Zen.webpack.status == 'done') {
-          this.workers.forEach(
-            (w) => w.tab && w.tab.setCodeHash(Zen.webpack.compile.hash)
-          )
-        }
-        this.sendStatus() // notify head of the compile status
+      Zen.webpack.on('status', () => {
+        this.sendStatus() 
       })
     }
 
     Zen.s3Sync.on('status', this.sendStatus.bind(this))
 
-    this.chrome = new ChromeWrapper() // headless chrome instance
-    this.chrome.launchLocal({ port: 9222 })
     new WebSocket.Server({ server }).on(
       'connection',
       this.onWebsocket.bind(this)
     )
-
-    // create a server for each worker. This gives us different origins and isolates things like localStorage
-    this.workersPromises = []
-    this.workers = Array.construct(8, (id) => {
-      id = id + 1
-      let port = Zen.config.port + id
-      http.createServer(app).listen(port)
-      let worker = { id, port }
-      this.workersPromises.push(
-        this.chrome
-          .openTab(
-            `http://localhost:${port}/worker?id=${id}`,
-            `w${id}`,
-            Zen.config,
-            {}
-          )
-          .then((t) => {
-            console.log('TAB', t)
-            worker.tab = t
-          })
-      )
-      return worker
-    })
 
     // host worker and head. NB this should go last after all other `app.use()` calls
     app.use(async (req, resp) => {
       resp.end(Zen.indexHtml(req.url.match(/^\/worker/) ? 'worker' : 'head'))
     })
   }
-
+  
   filterTests(msg) {
     // If nothing has changed and we're not running, leave the state unchanged.
     // When you refresh `head`, we don't want to run or clear out results unless the grep changed.
@@ -102,17 +70,13 @@ module.exports = class Server {
     this.passedFocus = []
 
     if (msg.run && Zen.webpack.status == 'done') {
-      if (msg.reload) {
-        this.workers.forEach((w) => w.tab.reload())
-      }
-
       this.runId++
-      this.grep ? this.runLocally() : this.runOnLambda(msg) // should this be if the tests will take less than x seconds?
+      this.runTests(msg)
       this.sendStatus()
     }
   }
 
-  async runOnLambda({ logs }) {
+  async runTests({ logs }) {
     let startingRunId = this.runId
     let runGroups = Zen.journal.groupTests(
       this.workingSet,
@@ -172,22 +136,6 @@ module.exports = class Server {
             }
           })
         )
-      }
-    })
-  }
-
-  async runLocally() {
-    let startingRunId = this.runId,
-      remaining = this.workingSet.clone()
-    this.isLambda = false
-    this.workerCount = this.workers.length
-    await Promise.all(this.workersPromises)
-    console.log(this.workers)
-    this.workers.forEach(async (w) => {
-      while (remaining.length > 0) {
-        let result = await w.tab.setTest({ testName: remaining.pop() })
-        if (!result || startingRunId !== this.runId) break // if the run was aborted
-        this.onResults([result])
       }
     })
   }


### PR DESCRIPTION
We only use the local chromium for when you run filtered tests.

Right now, this adds a bunch of extra setup for zen for little benefit and also makes running much more complicated. Doing this makes zen purely remote as most people assume, this also removes a class of issues like worker setup failure and chromium hanging around