### PR TITLE
remove rerun on timeout from workTests

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -183,20 +183,8 @@ export async function workTests(
 
   // If there are timeouts, then keep calling workTests again with the unresolved tests
   if (timeoutTests.length > 0 && rerun) {
-    console.log('RERUNNING DUE TO LAMBDA TIMEOUT', timeoutTests)
-    await timeout(30_000)
-    // We don't want this going on endlessly, because there are other errors we may want to do work
-    const newResponse = await workTests(
-      zen,
-      { ...args, testNames: timeoutTests },
-      false
-    )
-    timeoutTests.forEach((test) => {
-      response.results[test] = [
-        ...response.results[test],
-        ...newResponse.results[test],
-      ]
-    })
+    console.log('Lambda timeouts, waiting 10s for them to hopefully cleanout!')
+    await timeout(10_000)
   }
 
   return response


### PR DESCRIPTION
This fix caused a pretty degenerate case where you get stuck in a ton of test reruns. Instead of handling it here, handling it with the normal rerun logic prevents it from getting out of hand

For example, I have seen 10+ min zen runs because it gets stuck in this loop. I would rather zen fail in this case then keep beating at lambda while it is timing out