### PR TITLE
Desk 6483 fixtures returning 403

### DIFF
--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -422,10 +422,6 @@ export class ChromeTab {
     }
 
     if (!this.manifest || !isToGateway) {
-      console.log(`[${this.id}] continuing request to ${requestUrl}`)
-      console.log(`[${this.id}] manifest`, this.manifest)
-      console.log(`[${this.id}] gatewayUrl`, gatewayUrl)
-      console.log(`[${this.id}] isToGateway`, isToGateway)
       return defaultReturn()
     }
 
@@ -463,7 +459,6 @@ export class ChromeTab {
       } catch (e) {
         // There is a chance for a redirect or new tab while this s3 request is going through
         // if we try to fulfill a request that has been canceled chrome gets really angry
-        console.log(`[${this.id}] error fulfilling request`, e)
         console.error(e)
       }
     } else {

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -400,9 +400,18 @@ export class ChromeTab {
   }
 
   onRequestPaused = async (request: Puppeteer.HTTPRequest): Promise<void> => {
-    const gatewayUrl = process.env.GATEWAY_URL
+    let gatewayUrl = process.env.GATEWAY_URL
     const requestUrl = request.url()
-    const isToGateway = gatewayUrl && requestUrl.indexOf(gatewayUrl) >= 0
+    let isToGateway = gatewayUrl && requestUrl.indexOf(gatewayUrl) >= 0
+
+    // Temporary workaround
+    // Remove the pub from the end of the gateway url to make it
+    // work on heads that don't have the pub in the url
+    // TODO figure out why this is happening...
+    if (!isToGateway) {
+      gatewayUrl = gatewayUrl?.replace('/pub', '')
+      isToGateway = gatewayUrl && requestUrl.indexOf(gatewayUrl) >= 0
+    }
 
     const defaultReturn = async () => {
       try {
@@ -413,6 +422,10 @@ export class ChromeTab {
     }
 
     if (!this.manifest || !isToGateway) {
+      console.log(`[${this.id}] continuing request to ${requestUrl}`)
+      console.log(`[${this.id}] manifest`, this.manifest)
+      console.log(`[${this.id}] gatewayUrl`, gatewayUrl)
+      console.log(`[${this.id}] isToGateway`, isToGateway)
       return defaultReturn()
     }
 
@@ -450,6 +463,7 @@ export class ChromeTab {
       } catch (e) {
         // There is a chance for a redirect or new tab while this s3 request is going through
         // if we try to fulfill a request that has been canceled chrome gets really angry
+        console.log(`[${this.id}] error fulfilling request`, e)
         console.error(e)
       }
     } else {

--- a/lib/lambda.ts
+++ b/lib/lambda.ts
@@ -11,6 +11,7 @@ type WorkTestOpts = {
   deflakeLimit?: number
   runId: string
   oldResults?: WorkTestsResult
+  sessionId: string
 }
 export type WorkTestsResult = {
   results: Record<string, TestResult[]>
@@ -60,7 +61,7 @@ export const workTests = async (
     }
 
     const run = async () => {
-      const tab = await prepareChrome({ sessionId: '' })
+      const tab = await prepareChrome({ sessionId: opts.sessionId })
       const deflakeLimit = opts.deflakeLimit || 3
       for (let attempt = 1; attempt <= deflakeLimit; attempt++) {
         const remainingTests = getRemainingTests()
@@ -214,7 +215,6 @@ async function getManifest(sessionId: string) {
     manifest.files.forEach(
       (f) => (manifest.fileMap[f.urlPath] = f.versionedPath)
     )
-    console.log(manifest)
     manifest.assetUrl = `https://s3-${process.env.AWS_REGION}.amazonaws.com/${bucket}`
     return manifest
   } catch (e) {


### PR DESCRIPTION
This is what running all the tests looks like now on zen
There was usually 2-5 tests that flaked on every large run because of this bug. Now tests fail because they were written flakey :P

<img width="472" alt="Schermafbeelding 2022-11-22 om 4 14 57 PM" src="https://user-images.githubusercontent.com/7075897/203433537-a0356b6e-25e7-4e4d-ab7f-5fcf83d57fe6.png">
<img width="476" alt="Schermafbeelding 2022-11-22 om 4 14 08 PM" src="https://user-images.githubusercontent.com/7075897/203433539-5defe49b-56fc-4b91-8491-4e0b75d60da4.png">
