### PR TITLE
Attempt to make zen more stable and faster

### DIFF
--- a/lib/journal.ts
+++ b/lib/journal.ts
@@ -44,6 +44,26 @@ export default class Journal {
     }
   }
 
+  groupTestsWithDuplication(
+    tests: string[],
+    concurrency: number
+  ): { time: number; tests: string[] }[] {
+    let groups = this.groupTests(tests, concurrency)
+    // Take every group and add their content to anther group,
+    // this will help incase a single group fails due to a timeout
+    // or some other issue.
+    groups = groups.map((group, i) => {
+      const groupB = groups[(i + 1) % groups.length]
+      const groupC = groups[(i + 2) % groups.length]
+      return {
+        time: group.time + groupB.time + groupC.time,
+        tests: [...group.tests, ...groupB.tests, ...groupC.tests],
+      }
+    })
+
+    return groups
+  }
+
   groupTests(
     tests: string[],
     concurrency: number

--- a/lib/server.js
+++ b/lib/server.js
@@ -105,7 +105,6 @@ module.exports = class Server {
           const result = results.at(-1)
 
           if (!result) {
-            console.log(test, response.results, results)
             return {
               fullName: test,
               attempts: 0,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -13,6 +13,16 @@ export type TestResult = {
   log?: log
 }
 
+export type TestResultCollection = Record<
+  string,
+  {
+    results: TestResult[]
+    fullName: string
+    logStream?: string
+    success: boolean
+  }
+>
+
 export type Config = {
   log?: (metrics: metric[]) => Promise<void>
   appRoot: string


### PR DESCRIPTION
I am trying to cut a release for 3.19

This is an attempt to make zen much more stable. Now that we handle errors properly in zen, unstable lambdas and random flakes can make zen take super long to run.

The changes here work by duplicating tests across multiple lambdas, so if one fails the other will pick up the slack and hopefully succeed.

- [ ] Stabilize this duplication change
- [ ] Clean up the cli code