### PR TITLE
INF-836: Fix flaky timeout issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
-# 2022-5-5 0.3.20
+# 2023-05-15 0.3.21
+
+- Fix Zen test timeout issues
+- Constrain Zen bottom status bar to move only horizontally
+
+# 2023-05-05 0.3.20
 
 - Fix Zen AWS S3 upload sync flakiness
 
-# 2022-5-5 0.3.19
+# 2023-05-05 0.3.19
 
 - Fix eslint environment issues
 - Make Zen bottom status bar movable
 
-# 2022-5-26 0.3.17
+# 2022-05-26 0.3.17
 
 - Update Util.writeFile (#27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2023-05-15 0.3.22
+
+- Bump navigation timeout to 3 minutes
+
 # 2023-05-15 0.3.21
 
 - Fix Zen test timeout issues

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -522,7 +522,9 @@ export default class ChromeWrapper {
 
     const browser = await this.browser
     const page = await browser.newPage()
-    await page.setDefaultNavigationTimeout(0)
+
+    // set 3 mins timeout to reduce test flake on navigation timeout
+    await page.setDefaultNavigationTimeout(3 * 60 * 1000)
 
     const tab = new ChromeTab(browser, page, id, config, manifest, this.s3)
 

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -522,6 +522,8 @@ export default class ChromeWrapper {
 
     const browser = await this.browser
     const page = await browser.newPage()
+    await page.setDefaultNavigationTimeout(0)
+
     const tab = new ChromeTab(browser, page, id, config, manifest, this.s3)
 
     // TODO clean up order, right now it makes tab before goto to make the url stuff work properly

--- a/lib/mini.html
+++ b/lib/mini.html
@@ -72,6 +72,7 @@
   .mini {
     all: initial;
     position: fixed;
+    bottom: 0;
     width: 400px;
     padding: 8px 5px 4px 5px;
     border: 1px solid #ddd;
@@ -197,16 +198,14 @@
   export default {
     oncreate() {
       // set left and bottom as px
-      const { left, top, height } = this.refs.mini.getBoundingClientRect()
+      const { left } = this.refs.mini.getBoundingClientRect()
       this.set({
         left: `${window.innerWidth / 2 - 200}px`,
-        top: `${window.innerHeight - height}px`,
       })
     },
     data() {
       return {
         moving: false,
-        top: '0',
         left: '0',
       }
     },
@@ -219,8 +218,7 @@
       },
       onMouseMove(e) {
         const { moving } = this.get()
-        const { left, top, width, height } =
-          this.refs.mini.getBoundingClientRect()
+        const { left, width } = this.refs.mini.getBoundingClientRect()
 
         if (moving) {
           // constrain element horizontally within window
@@ -228,14 +226,8 @@
             Math.max(left + e.movementX, 0),
             window.innerWidth - width
           )
-          // constrain element vertically within window
-          const newTop = Math.min(
-            Math.max(top + e.movementY, 0),
-            window.innerHeight - height
-          )
           this.set({
             left: `${newLeft}px`,
-            top: `${newTop}px`,
           })
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
# [INF-836](https://linear.app/superhuman/issue/INF-836/flaky-zen-test-navigation-timeout-exceeds-30000)

- Fix timeout issue on Zen tests
- Constraint Zen UI to only move horizontally

Reference: [https://ourcodeworld.com/articles/read/1106/how-to-solve-puppeteer-timeouterror-navigation-timeout-of-30000-ms-exceeded](https://ourcodeworld.com/articles/read/1106/how-to-solve-puppeteer-timeouterror-navigation-timeout-of-30000-ms-exceeded)