### PR TITLE
Make wasm sqlite work with Zen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2024-06-07 0.3.24
+
+- Modify webpack to work with wasm sqlite for local dev.
+- Adds security headers to server for wasm.
+- Adds `setDevelopmentHeaders` config option so we can modify the dev response headers with
+the correct csp.
+- Removes `HotModuleReplacementPlugin` we can't use this with webworkers for our currentl webpack setup since this module depends on `window` existing. The zen will still hard reload the page on file change.
+
 # 2023-06-12 0.3.23
 
 - Add timeout configuration option to Latte

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@
 * Bump the version number in `package.json`
 * Add a line item to `CHANGELOG.md`
 * Run `npm publish`
+
+# Developing Locally
+
+If you want to develop locally against the Superhuman desktop repo you can:
+
+- Run `yarn link` in this repo (you only need to do this once after downloading the repo)
+- Go to the Superhuman desktop repo and run `yarn link @superhuman/zen`
+- Run `yarn start` in this repo to build the zen library
+
+- When you are done run `yarn unlink @superhuman/zen` in the desktop repo.

--- a/lib/head.js
+++ b/lib/head.js
@@ -334,7 +334,12 @@ async function runIfCodeChanged() {
 
   // If we loaded before the first compile, reload once the code is ready
   // ZenWebpackClient can be undefined while errored or still bundling
-  if (compile.hash && !window.ZenWebpackClient) return location.reload()
+  if (compile.hash && !window.ZenWebpackClient) {
+    location.reload()
+  }
+  if (ZenWebpackClient.needsUpdate(store.get().compile.hash)) {
+    location.reload()
+  }
 
   if (!ZenWebpackClient.needsUpdate(compile.hash)) return
 
@@ -343,11 +348,7 @@ async function runIfCodeChanged() {
   hotReloading = true
   console.clear()
   await Latte.cleanup() // Run all after(Each) in preparation for our new code
-  while (ZenWebpackClient.needsUpdate(store.get().compile.hash)) {
-    await ZenWebpackClient.update()
-  }
   hotReloading = false
-
   testsHaveChanged()
   focusTest()
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,40 +9,43 @@ import WebpackAdapter from './webpack'
 import type { metric } from './profiler'
 
 require('sugar').extend()
+
+export type ZenConfig = {
+  log?: (metrics: metric[]) => Promise<void>
+  appRoot: string
+  setDevelopmentHeaders: (req: any, res: any) => void
+  port: number
+  testDependencies: string[]
+  lambdaConcurrency: number
+  htmlTemplate: string
+  sessionId: string
+  useSnapshot: boolean
+  tmpDir: string
+  alsoServe: { addToIndex: boolean; filePath: string }[]
+
+  // TODO flesh this out
+  aws: any
+
+  // TODO flesh this out
+  webpack: any
+  chrome?: {
+    width?: number
+    height?: number
+  },
+  lambdaNames: {
+    // The others are actually never used
+    workTests: string,
+    listTests: string
+  }
+}
+
 export type Zen = {
   s3Sync: S3Sync
   lambda: AWS.Lambda
   journal: Journal
   webpack: WebpackAdapter
   indexHtml: (pageType: string, forS3: boolean) => string
-
-  config: {
-    log?: (metrics: metric[]) => Promise<void>
-    appRoot: string
-    port: number
-    testDependencies: string[]
-    lambdaConcurrency: number
-    htmlTemplate: string
-    sessionId: string
-    useSnapshot: boolean
-    tmpDir: string
-    alsoServe: { addToIndex: boolean; filePath: string }[]
-
-    // TODO flesh this out
-    aws: any
-
-    // TODO flesh this out
-    webpack: any
-    chrome?: {
-      width?: number
-      height?: number
-    },
-    lambdaNames: {
-      // The others are actually never used
-      workTests: string,
-      listTests: string
-    }
-  }
+  config: ZenConfig
 }
 
 export default async function initZen(configFilePath: string): Promise<Zen> {
@@ -132,7 +135,7 @@ export default async function initZen(configFilePath: string): Promise<Zen> {
 
   if (config.webpack) {
     // boot up webpack (if configured)
-    Zen.webpack = new WebpackAdapter(config.webpack)
+    Zen.webpack = new WebpackAdapter(config)
   }
 
   // TODO clean this up to remove the casting

--- a/lib/server.js
+++ b/lib/server.js
@@ -73,6 +73,9 @@ module.exports = class Server {
 
     // host worker and head. NB this should go last after all other `app.use()` calls
     app.use(async (req, resp) => {
+      // Required to use WASM Sqlite.
+      resp.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+      resp.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
       resp.end(Zen.indexHtml(req.url.match(/^\/worker/) ? 'worker' : 'head'))
     })
   }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,8 +16,7 @@
   Zen.upgrade = async function (hash) {
     await Latte.waitForCurrentTest()
     await Latte.cleanup() // we shouldn't upgrade until the `after` blocks have run
-    // TODO double check this code path
-    await ZenWebpackClient.update(hash)
+    location.reload()
     batchId = workerId + Date.now()
     console.log('Zen.hotReload - ' + hash)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
- Modify webpack to work with wasm sqlite for local dev.
- Adds security headers to server for wasm.
- Adds `setDevelopmentHeaders` config option so we can modify the dev response headers with
the correct csp.
- Removes `HotModuleReplacementPlugin` we can't use this with webworkers for our current webpack setup since this module depends on `window` existing. The zen will still hard reload the page on file change.

From testing locally I don't think the hotmodulereplacement removal has broken anything as far as I can tell.

[Corresponding Superhuman PR](https://github.com/superhuman/desktop/pull/24766)