### PR TITLE
Zen tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2024-06-17 0.3.26
+
+- Reset worker reloading logic to original logic from 0.3.23
+- Don't use COEP headers when running on remote since this breaks the fetching of the s3 files.
+
+# 2024-06-17 0.3.25
+
+- Test release. No changes.
+
 # 2024-06-07 0.3.24
 
 - Modify webpack to work with wasm sqlite for local dev.

--- a/lib/server.js
+++ b/lib/server.js
@@ -73,10 +73,16 @@ module.exports = class Server {
 
     // host worker and head. NB this should go last after all other `app.use()` calls
     app.use(async (req, resp) => {
-      // Required to use WASM Sqlite.
-      resp.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
-      resp.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
-      resp.end(Zen.indexHtml(req.url.match(/^\/worker/) ? 'worker' : 'head'))
+      const isRemote = req.url.match(/^\/worker/)
+
+      if (!isRemote) {
+        // Required to use WASM Sqlite.
+        // Currently wasm sqlit is only running on local dev.
+        resp.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+        resp.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+      }
+
+      resp.end(Zen.indexHtml(isRemote ? 'worker' : 'head'))
     })
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,7 +16,8 @@
   Zen.upgrade = async function (hash) {
     await Latte.waitForCurrentTest()
     await Latte.cleanup() // we shouldn't upgrade until the `after` blocks have run
-    location.reload()
+    // TODO double check this code path
+    await ZenWebpackClient.update(hash)
     batchId = workerId + Date.now()
     console.log('Zen.hotReload - ' + hash)
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.24",
+  "version": "0.3.26",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {
+    "release-new-version": "yarn build && npm publish",
     "example": "(cd example && node --inspect ../lib/index.js zen.js)",
     "test": "echo \"Ironic: no test specified\" && exit 1",
     "format": "prettier --write --ignore-unknown .",
@@ -66,7 +67,7 @@
     "prettier": "^2.4.1",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.3",
-    "webpack": "4.46.0",
+    "webpack": "4.47.0",
     "webpack-dev-server": "^3.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,10 +4989,10 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.46.0:
-  version "4.46.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
-  integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==
+webpack@4.47.0:
+  version "4.47.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.47.0.tgz#8b8a02152d7076aeb03b61b47dad2eeed9810ebc"
+  integrity sha512-td7fYwgLSrky3fI1EuU5cneU4+pbH6GgOfuKNS1tNPcfdGinGELAqsb/BP4nnvZyKSG2i/xFGU7+n2PvZA8HJQ==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"


### PR DESCRIPTION
- Only set wasm headers on local. Headers cause issues on remote due to disabling CORS requests. Remote hits s3 buckets for assets.
- reset `location.reload()` change from 0.3.24. This was causing bugs with loading page on remote.
- Bump webpack version to match main app.