### PR TITLE
Improve error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2024-08-28 0.3.29
+
+- Correctly capture and log page errors
+- Remove unhelpful console log
+- Fix console log stack traces in `debug` (local) mode
+- Capture and log errors in afterEach blocks on `headless` (remote) mode
+- Run linter / formatter
+
 # 2024-06-17 0.3.28
 
 - Minor logging changes
@@ -20,7 +28,7 @@
 - Modify webpack to work with wasm sqlite for local dev.
 - Adds security headers to server for wasm.
 - Adds `setDevelopmentHeaders` config option so we can modify the dev response headers with
-the correct csp.
+  the correct csp.
 - Removes `HotModuleReplacementPlugin` we can't use this with webworkers for our currentl webpack setup since this module depends on `window` existing. The zen will still hard reload the page on file change.
 
 # 2023-06-12 0.3.23

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Publishing a new version
 
-* Log into `npm` with an account that has publish permissions (if you don't have
+- Log into `npm` with an account that has publish permissions (if you don't have
   this, create one and ask Conrad): `npm login`
-* Bump the version number in `package.json`
-* Add a line item to `CHANGELOG.md`
-* Run `npm publish`
+- Bump the version number in `package.json`
+- Add a line item to `CHANGELOG.md`
+- Run `npm publish`
 
 # Developing Locally
 

--- a/lib/chrome_wrapper.ts
+++ b/lib/chrome_wrapper.ts
@@ -123,6 +123,10 @@ class ChromeTab {
     this.page.on('error', (error) => {
       this.onExceptionThrown(error)
     })
+    this.page.on('pageerror', (error: Error) => {
+      console.log(error)
+      this.onMessageAdded(error.message + ':' + error.stack)
+    })
   }
 
   async resizeWindow({ width, height }: { width: number; height: number }) {

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -159,9 +159,12 @@ async function run(zen: Zen, opts: CLIOptions) {
 
     t0 = Date.now()
     console.log('Getting test names')
-    let workingSet: string[] = await Util.invoke(zen.config.lambdaNames.listTests, {
-      sessionId: zen.config.sessionId,
-    })
+    let workingSet: string[] = await Util.invoke(
+      zen.config.lambdaNames.listTests,
+      {
+        sessionId: zen.config.sessionId,
+      }
+    )
 
     // In case there is an infinite loop, this should brick the test running
     let runsLeft = 5

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -31,10 +31,10 @@ export type ZenConfig = {
   chrome?: {
     width?: number
     height?: number
-  },
+  }
   lambdaNames: {
     // The others are actually never used
-    workTests: string,
+    workTests: string
     listTests: string
   }
 }
@@ -71,7 +71,7 @@ export default async function initZen(configFilePath: string): Promise<Zen> {
   config.useSnapshot === undefined ? true : !!config.useSnapshot
   config.lambdaNames = config.lambdaNames || {
     workTests: 'zen-workTests',
-    listTests: 'zen-listTests'
+    listTests: 'zen-listTests',
   }
 
   // tmpDir is where we cache files between runs

--- a/lib/lambda.js
+++ b/lib/lambda.js
@@ -3,12 +3,12 @@ let wrapper // store chrome wrapper globally. In theory we could reuse this betw
 
 module.exports.workTests = async (opts, context) => {
   // TODO: the 1s buffer will help, most of the time but the extendRemoteTimeout may cause issues with this
-  
+
   // 5s to safely setup zen
   const maxRunTime = (opts.lambdaCutoff || 60) * 1000 - 5_000
   // 5s more off to have a safe 10s to run a final test
   const cutoff = Date.now() + maxRunTime - 5_000
-  const cutoffTimeout = new Promise(res => setTimeout(res, maxRunTime))
+  const cutoffTimeout = new Promise((res) => setTimeout(res, maxRunTime))
   let results = []
   const runTests = async () => {
     // Run all tests once, collecting results
@@ -49,7 +49,7 @@ module.exports.workTests = async (opts, context) => {
 
   let tab = await prepareChrome(opts)
   await Promise.race([cutoffTimeout, runTests()])
-  
+
   // Track the logStreamName, so it's easy to open the logs of a failed test
   results.forEach((r) => (r.logStream = context.logStreamName))
 
@@ -145,7 +145,7 @@ async function prepareChrome(opts) {
     wrapper = new ChromeWrapper()
     await wrapper.launchLambda()
   } else {
-    console.log("Chrome is already running!")
+    console.log('Chrome is already running!')
   }
 
   console.log('Opening tab')

--- a/lib/server.js
+++ b/lib/server.js
@@ -56,15 +56,15 @@ module.exports = class Server {
       let port = Zen.config.port + id
       http.createServer(app).listen(port)
       let worker = { id, port }
-      this.workersPromises.push(this.chrome
+      this.workersPromises.push(
+        this.chrome
           .openTab(
-              `http://localhost:${port}/worker?id=${id}`,
-              `w${id}`,
-              Zen.config,
-              { }
+            `http://localhost:${port}/worker?id=${id}`,
+            `w${id}`,
+            Zen.config,
+            {}
           )
           .then((t) => {
-            console.log("TAB", t)
             worker.tab = t
           })
       )

--- a/lib/webpack/webpack-client.ts
+++ b/lib/webpack/webpack-client.ts
@@ -1,6 +1,6 @@
 module.hot?.accept((err) => {
   // TODO I think this might be the source of refresh looping
-  console.log("LOOPING")
+  console.log('LOOPING')
   if (err) location.reload()
 })
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -9,9 +9,13 @@
     console.log(`Zen.resizeWindow ${JSON.stringify({ height, width })}`)
   }
 
-  Latte.setup({ mode: 'headless', willHotReload: true, helpers: {
-    resizeWindow
-  } })
+  Latte.setup({
+    mode: 'headless',
+    willHotReload: true,
+    helpers: {
+      resizeWindow,
+    },
+  })
 
   Zen.upgrade = async function (hash) {
     await Latte.waitForCurrentTest()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
# Summary 

Copied from `changelog`: 

- Correctly capture and log page errors
- Remove unhelpful console log
- Fix console log stack traces in `debug` (local) mode
- Capture and log errors in afterEach blocks on `headless` (remote) mode
- Run linter / formatter