### PR TITLE
wrap websocket messages json parsing in a try/catch

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -172,10 +172,14 @@ module.exports = class Server {
   onWebsocket(ws) {
     this.head = ws
     ws.on('message', (msg) => {
-      msg = JSON.parse(msg)
-      if (msg.type === 'filterTests') this.filterTests(msg)
-      if (msg.type === 'passedFocus') this.passedFocus.push(msg.test)
-      this.sendStatus()
+      try {
+        msg = JSON.parse(msg)
+        if (msg.type === 'filterTests') this.filterTests(msg)
+        if (msg.type === 'passedFocus') this.passedFocus.push(msg.test)
+        this.sendStatus()
+      } catch (e) {
+        console.error(e)
+      }
     })
     ws.on('error', (err) => {
       console.error('Websocket error', err)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
# Summary
Fixes zen crashing when you repeatedly / rapidly save the same file. 

# Changes
Wrap json.parse() in a try catch when receiving websocket messages. 

## Underlying error: 
```
ConsoleMessage {}
- 00ab756aeb8e0ba99e9f
undefined:1
- 00ab756aeb8e0ba99e9f
 ^

SyntaxError: Unexpected token   in JSON at position 1
    at JSON.parse (<anonymous>)
    at register (/Users/patrickbakke/www/desktop/node_modules/@superhuman/zen/build/cli.js:3097:30)
    at ChromeTab.onMessageAdded (/Users/patrickbakke/www/desktop/node_modules/@superhuman/zen/build/cli.js:3104:9)
    at /Users/patrickbakke/www/desktop/node_modules/@superhuman/zen/build/cli.js:2976:16
    at /Users/patrickbakke/www/desktop/node_modules/puppeteer/lib/cjs/vendor/mitt/src/index.js:51:68
    at Array.map (<anonymous>)
    at /Users/patrickbakke/www/desktop/node_modules/@superhuman/zen/node_modules/sugar/enumerable/internal/wrapNativeArrayMethod.js:12:21
    at Array.staticFn.instance (/Users/patrickbakke/www/desktop/node_modules/@superhuman/zen/node_modules/sugar/common/internal/fixArgumentLength.js:10:12)
...
```

