### PR TITLE
Reset dev server syntax to old style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 2024-11-06 0.3.31
 
+- reset dev server calling args to old format
+
+# 2024-11-06 0.3.31
+
 - Update aws-sdk and serve-static deps and update dev server to new format.
 
 # 2024-08-28 0.3.30

--- a/lib/webpack/index.ts
+++ b/lib/webpack/index.ts
@@ -111,12 +111,11 @@ module.exports = class WebpackAdapter extends EventEmitter {
       }
     }
 
-    const devServer = new WebpackDevServer({
-      devMiddleware: {
-        stats: { errorDetails: true },
-      },
-      hot: true
-    }, this.compiler)
+    const devServer = new WebpackDevServer(this.compiler, {
+      stats: { errorDetails: true },
+      hot: true,
+      inline: false,
+    })
 
     // @ts-expect-error app does exist in this version of dev server
     server.use('/webpack', devServer.app)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superhuman/zen",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Karma replacement that runs your tests in seconds",
   "main": "lib/cli.js",
   "scripts": {


### PR DESCRIPTION
Bumping the dev-server version caused a huge cascade of zen issues so it's being reset to the old syntax for now.